### PR TITLE
Add gh actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # Skip if pushing to master because then other workflow will run
+    if: ${{ (github.event_name == 'push' && github.ref != 'refs/heads/master') || github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Build Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # Skips root build script (so no `yarn run build` is run)
+          skip_build: true
+          # Runs `vue-cli-service electron:build`
+          use_vue_cli: true
+
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+          release: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # Skips root build script (so no `yarn run build` is run)
+          skip_build: true
+          # Runs `vue-cli-service electron:build`
+          use_vue_cli: true
+
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+          release: true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ You need to have [Node.js](https://nodejs.org/en/) version >= 12.9 installed. It
 ---
 ## How to install the application
 
+### Install from sources
+
 **Step 1:** Clone the repository to your local machine.
 
 ```
@@ -75,6 +77,12 @@ yarn run electron:build
 ```
 
 **Step 4:** Navigate into the folder 'dist_electron' and install the application. After installing it you can start the application on your machine.
+
+### Install from releases
+
+You can also download the pre-built version of the application directly from the Releases tab of this repository.
+The installer specific to your platform can be found within the Assets section of a release.
+Keep in mind, that running the software under Mac OS requires [additional steps](https://support.apple.com/en-mn/guide/mac-help/mh40616/mac). 
 
 ---
 ## How to get started with development


### PR DESCRIPTION
This PR adds the following GitHub Actions to the repository:

1. Build. This action is run every time a new Pull Request is created or a push to a non-master branch happens. It builds the software with Node version 16 under Linux and checks that the build process completes successfully (Linux artifacts are created).
2. Release. This action is run every time a push to the master branch happens (for example, after merging a PR). It builds the software with Node version 16 under the 3 operating systems (Ubuntu, Windows, and macOS), and in case of success creates and releases the artifacts for each platform, which then can be found as a draft release under the Releases tab of GitHub.